### PR TITLE
Adding a custom 404 page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -4,6 +4,7 @@ import Layout from '../components/layout';
 export default () => {
     return (
         <Layout>
+            {/* TODO: Replace inline style with styled component when that package is merged */}
             <div style={{textAlign: 'center'}}>
               <h1>Error 404</h1>
               <p>Page not found.</p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8367927/73399205-b0b16000-429b-11ea-9644-eddda09f51e4.png)

Currently getting a Google Cloud build error due to lack of 404 page. Hoping this will fix that.

![image](https://user-images.githubusercontent.com/8367927/73398838-06d1d380-429b-11ea-838f-222998c4f726.png)

[See the log](https://console.cloud.google.com/logs/viewer?project=ai2-reviz&resource=k8s_container%2Fcluster_name%2Fskiff-production%2Fnamespace_name%2Fallennlp-course&filters=label:k8s-pod%2Fapp:allennlp-course&filters=label:k8s-pod%2Fenv:staging&angularJsUrl=%2Flogs%2Fviewer%3Fproject%3Dai2-reviz%26resource%3Dk8s_container%252Fcluster_name%252Fskiff-production%252Fnamespace_name%252Fallennlp-course%26filters%3Dlabel%253Ak8s-pod%252Fapp%253Aallennlp-course%26filters%3Dlabel%253Ak8s-pod%252Fenv%253Astaging&authuser=3&minLogLevel=0&expandAll=false&timestamp=2020-01-29T20:59:57.028000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-01-29T19:59:57.282Z&dateRangeEnd=2020-01-29T20:59:57.282Z&interval=PT1H&scrollTimestamp=2020-01-29T20:57:47.370277164Z).