### PR TITLE
Updating skiff config to support marina build status

### DIFF
--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -30,15 +30,17 @@ steps:
     'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   ]
 # Generate our Kubernetes configuration
-- id: 'config'
+- id: 'config-webapp'
   name: 'gcr.io/ai2-reviz/jsonnet'
   args: [
     'eval',
     '-y',
     '--output-file', './webapp.json',
     '--ext-str', 'env=$_ENV',
-    '--ext-str', 'image=gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
     '--ext-str', 'sha=$COMMIT_SHA',
+    '--ext-str', 'image=gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+    '--ext-str', 'buildId=$BUILD_ID',
+    '--ext-str', 'repo=$REPO_NAME',
     './webapp.jsonnet'
   ]
   dir: '.skiff'

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -105,7 +105,10 @@ local ingress = {
             'certmanager.k8s.io/cluster-issuer': 'letsencrypt-prod',
             'kubernetes.io/ingress.class': 'nginx',
             'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-            'nginx.ingress.kubernetes.io/enable-cors': 'false'
+            'nginx.ingress.kubernetes.io/enable-cors': 'false',
+            'apps.allenai.org/build': std.extVar('buildId'),
+            'apps.allenai.org/sha': std.extVar('sha'),
+            'apps.allenai.org/repo': std.extVar('repo')
         }
     },
     spec: {


### PR DESCRIPTION
This PR aims to solve the following issue with the [`allennlp-course` page on Marina](https://marina.apps.allenai.org/a/allennlp-course):

![image](https://user-images.githubusercontent.com/8367927/73482962-8622de00-4353-11ea-883f-b15011cfb815.png)

I made these changes based on https://github.com/allenai/skiff/blob/master/doc/UserGuide.md#why-doesnt-my-application-have-build-statuses-version-information-and-adhoc-support

Note that I also changed the Kubernetes configuration id from `'config'` to `'config-webapp'` to match the docs.