### PR TITLE
Increasing timeout limit in deploy manifest

### DIFF
--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -63,3 +63,4 @@ artifacts:
   objects:
     location: 'gs://skiff-archive/$REPO_NAME/$_ENV/$BUILD_ID/$COMMIT_SHA'
     paths: ['.skiff/webapp.json']
+timeout: 1200s


### PR DESCRIPTION
Addresses https://github.com/allenai/allennlp-course/issues/49 (hopefully fixes it).

Increasing timeout from **10min** to **20min** (`1200s`)

Fix is based on docs that Sam pointed me towards: https://cloud.google.com/cloud-build/docs/build-config#timeout_2