### PR TITLE
Fixing chapter page layout bug on staging

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -135,7 +135,8 @@ const GlobalStyle = createGlobalStyle`
         flex: 1;
     }
 
-    #___gatsby > div[role="group"] {
+    #___gatsby > div[role="group"],
+    #gatsby-focus-wrapper {
         display: flex;
         flex-direction: column;
         height: 100%;


### PR DESCRIPTION
**This PR**
- Adds a build-specific `div` selector to the root container list in the height override css. This `id` appears to only exist when the pages are statically built (i.e. server-side rendered, i.e. prod/staging), but not when they're being dynamically rendered in real-time during local development.
- Fixes https://github.com/allenai/allennlp-course/issues/63