### PR TITLE
Separating about text from meta description

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,7 +1,7 @@
 {
     "courseId": "allennlp-intro-course",
     "title": "Diving Into Natural Language Processing With AllenNLP",
-    "description": "We walk through the basics of using AllenNLP, describing all of the main abstractions used and why we chose them, how to use specific functionality like configuration files or pre-trained representations, and how to build various kinds of models, from simple to complex.",
+    "description": "In this course, we'll walk through the basics of using AllenNLP, describing all of the main abstractions used and how to build various kinds of models.",
     "siteUrl": "https://allennlp.org/",
     "twitter": "ai2_allennlp",
     "testTemplate": "from wasabi import Printer\n__msg__ = Printer()\n__solution__ = \"\"\"${solution}\"\"\"\n\n${solution}\n\n${test}\n\ntry:\n    test()\nexcept AssertionError as e:\n    __msg__.fail(e)",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,7 +25,7 @@ export default ({ data }) => {
             <About>
                 <SectionIntro>
                     <h2>About this course</h2>
-                    <p>{data.site.siteMetadata.description}</p>
+                    <p>We walk through the basics of using AllenNLP, describing all of the main abstractions used and why we chose them, how to use specific functionality like configuration files or pre-trained representations, and how to build various kinds of models, from simple to complex.</p>
                 </SectionIntro>
                 <PartContainer>
                     <StandaloneChapterLink to={outline.overview.slug}>
@@ -115,7 +115,7 @@ const SectionIntro = styled.div`
     h2 {
         ${({ theme }) => theme.typography.h4};
     }
-    
+
     p {
         margin: 0;
         padding-top: ${({ theme }) => theme.spacing.xxs};
@@ -172,7 +172,7 @@ const PartHeaderText = styled.div`
     flex: 1;
     display: flex;
     flex-direction: column;
-    
+
     & > :last-child {
         margin-bottom: 0;
     }
@@ -190,7 +190,7 @@ const BeginLink = styled.div`
     display: grid;
     grid-template-columns: max-content;
     margin-top: auto;
-    
+
     div {
         display: flex;
         align-items: center;
@@ -215,7 +215,7 @@ const StandaloneChapterLink = styled(Link)`
             ${PartTitle} {
                 color: ${({ theme }) => theme.color.B6};
             }
-            
+
             p {
                 color: ${({ theme }) => theme.palette.text.primary};
             }
@@ -333,7 +333,7 @@ const ChapterListTrigger = styled.div`
 const TriggerTooltip = styled.span`
     ${({ theme }) => theme.typography.bodySmall}
     color: ${({ theme }) => theme.color.B6};
-    
+
     &:hover {
         text-decoration: underline;
     }


### PR DESCRIPTION
**This PR**

- Proposes a simplified meta description text (would look like the mockup below in a SERP)
- Decouples about content on home page from meta description field (that field is meant more for search result description text and embedded social card description)
- Auto-cleans up some extra whitespace in `index.js`

---

![image](https://user-images.githubusercontent.com/8367927/75018890-c520ec80-5444-11ea-91a1-6a32734c220d.png)
