### PR TITLE
Adding part title to chapter template

### DIFF
--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -149,6 +149,9 @@ const Template = ({ data, location }) => {
                                     />
                                 </div>
                                 <ChapterIntroText>
+                                    {!isOverview && (
+                                        <PartTitle>{thisPart.title}</PartTitle>
+                                    )}
                                     {title && <h1>{title}</h1>}
                                     {description && (
                                         <p>{description}</p>
@@ -601,7 +604,15 @@ const ChapterIntroText = styled.div`
 
     p {
         ${({ theme }) => theme.typography.bodyBig}
+        color: ${({ theme }) => theme.color.N10};
     }
+`;
+
+const PartTitle = styled.strong`
+    ${({ theme }) => theme.typography.h6}
+    display: block;
+    text-transform: uppercase;
+    margin: 0 0 23px 2px;
 `;
 
 // Previous / Next chapter buttons


### PR DESCRIPTION
**This PR**
- Adds Part title to top of chapter page, per approved design
- Updates intro text color to a slightly darker shade for more contrast
- Looks like this:

![image](https://user-images.githubusercontent.com/8367927/75322583-e1979d00-5827-11ea-821e-d8c7632cb417.png)

Overview still looks the way it did before:

![image](https://user-images.githubusercontent.com/8367927/75322622-f96f2100-5827-11ea-9f51-e05e48fd57e3.png)
