### PR TITLE
support guide.allennlp.org

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -51,12 +51,11 @@ local topLevelDomain = '.apps.allenai.org';
 // at this point, as that's all our certmanager can (easily) handle. At one
 // point we may support additional domain names. If you support for this, let
 // us know! https://github.com/allenai/skiff/issues/new
-local hosts = [
+local hosts =
     if env == 'prod' then
-        config.appName + topLevelDomain
+        [ 'guide.allennlp.org', config.appName + topLevelDomain ]
     else
-        config.appName + '.' + env + topLevelDomain
-];
+        [ config.appName + '.' + env + topLevelDomain ];
 
 local replicas = (
     if env == 'prod' then


### PR DESCRIPTION
I made guide.allennlp.org point at the Skiff ingress:

```
$ host guide.allennlp.org 8.8.8.8
Using domain server:
Name: 8.8.8.8
Address: 8.8.8.8#53
Aliases: 

guide.allennlp.org has address 34.82.0.50
```

So this change will make Skiff route requests for this hostname to this app, and should make the proper cert be generated.