### PR TITLE
fix: iterator to data_loader (ch1 next steps)

### DIFF
--- a/chapters/part1/next-steps.md
+++ b/chapters/part1/next-steps.md
@@ -94,9 +94,9 @@ local bert_model = "bert-base-uncased";
             "requires_grad": false
         }
     },
-    "iterator": {
-        "type": "basic",
-        "batch_size": 8
+    "data_loader": {
+        "batch_size": 8,
+        "shuffle": true
     },
     "trainer": {
         "optimizer": {


### PR DESCRIPTION
Minor issue in the Next Steps section in Ch.1 where the example config uses the deprecated iterator instead of data_loader.