### PR TITLE
Add Skiff Stats.

### DIFF
--- a/src/components/Head.js
+++ b/src/components/Head.js
@@ -100,6 +100,12 @@ const Head = ({ title, description }) => (
                             gtag('config', '${gaId}');
                         `}</script>
                     )}
+                    <script
+                        src="https://stats.allenai.org/init.min.js"
+                        data-spa="true"
+                        data-app-name="allennlp-guide"
+                        async
+                    />
                 </Helmet>
             );
         }}


### PR DESCRIPTION
This adds support for Skiff Stats. You might be able to drop Google
Analytics of the resulting metrics suffice for your use case. This is
better for users, as it stops shipping their data to Google. It's also
a bit faster, as the required JavaScript is smaller.