### PR TITLE
Add note for users to use pruning callback with AllenNLPExecutor

### DIFF
--- a/chapters/part2/hyperparameter-optimization.md
+++ b/chapters/part2/hyperparameter-optimization.md
@@ -350,6 +350,13 @@ if __name__ == '__main__':
 
 <exercise id="6" title="Pruning poor performing trials">
 
+### Attention!
+
+The pruning integration for AllenNLP is a new feature and not released yet.
+Please install Optuna from the master branch to try this feature in your environment.
+
+`pip install git+https://github.com/optuna/optuna.git@master`
+
 Hyperparameter optimization often takes a long time to find good hyperparameters.
 If you can find and stop unpromising trials with bad hyperparameters, you can reduce the time of optimization and get good hyperparameters faster.
 Stopping unpromising trials is called `pruning`.


### PR DESCRIPTION
Follow up for https://github.com/allenai/allennlp-guide/pull/138#discussion_r484032868

`AllenNLPPruningCallback` integration for optimizing AllenNLP model with Jsonnet is the new feature of Optuna
and not released yet. (it's merged to master branch at https://github.com/optuna/optuna/pull/1772)

So, for the section for pruning, please let me add a note for guiding users to install Optuna from the master branch until Optuna v2.2.0 is released. I'll remove this note as soon as possible when the release is out.