### PR TITLE
Update data_loader_setup.py

### DIFF
--- a/exercises/part2/reading-data/data_loader_setup.py
+++ b/exercises/part2/reading-data/data_loader_setup.py
@@ -5,7 +5,7 @@ from allennlp.data.data_loaders import MultiProcessDataLoader
 from allennlp.data.fields import LabelField, TextField
 from allennlp.data.tokenizers import Token
 from allennlp.data.token_indexers import SingleIdTokenIndexer
-from allennlp.data.batch_samplers import BucketBatchSampler
+from allennlp.data.samplers.bucket_batch_sampler import BucketBatchSampler
 from allennlp.data.vocabulary import Vocabulary
 
 


### PR DESCRIPTION
With the current version, an error occurs while running the code in the binder: https://guide.allennlp.org/reading-data#4. BucketBatchSampler should now be imported from a different place.