### PR TITLE
Update quick start predict py

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 # Checks style, syntax, and other useful errors.
 flake8
 mypy==0.812
-black==20.8b1
+black==21.7b0

--- a/quick_start/predict.py
+++ b/quick_start/predict.py
@@ -52,7 +52,7 @@ class ClassificationTsvReader(DatasetReader):
         return Instance(fields)
 
     def _read(self, file_path: str) -> Iterable[Instance]:
-        with open(file_path, 'r') as lines:
+        with open(file_path, "r") as lines:
             for line in lines:
                 text, sentiment = line.strip().split('\t')
                 yield self.text_to_instance(text, sentiment)
@@ -99,8 +99,8 @@ def build_dataset_reader() -> DatasetReader:
 
 def read_data(reader: DatasetReader) -> Tuple[List[Instance], List[Instance]]:
     print("Reading data")
-    training_data = list(reader.read("data/movie_review/train.tsv"))
-    validation_data = list(reader.read("data/movie_review/dev.tsv"))
+    training_data = list(reader.read("quick_start/data/movie_review/train.tsv"))
+    validation_data = list(reader.read("quick_start/data/movie_review/dev.tsv"))
     return training_data, validation_data
 
 

--- a/quick_start/predict.py
+++ b/quick_start/predict.py
@@ -46,15 +46,15 @@ class ClassificationTsvReader(DatasetReader):
         if self.max_tokens:
             tokens = tokens[: self.max_tokens]
         text_field = TextField(tokens, self.token_indexers)
-        fields = {'text': text_field}
+        fields = {"text": text_field}
         if label:
-            fields['label'] = LabelField(label)
+            fields["label"] = LabelField(label)
         return Instance(fields)
 
     def _read(self, file_path: str) -> Iterable[Instance]:
         with open(file_path, "r") as lines:
             for line in lines:
-                text, sentiment = line.strip().split('\t')
+                text, sentiment = line.strip().split("\t")
                 yield self.text_to_instance(text, sentiment)
 
 
@@ -82,11 +82,11 @@ class SimpleClassifier(Model):
         logits = self.classifier(encoded_text)
         # Shape: (batch_size, num_labels)
         probs = torch.nn.functional.softmax(logits)
-        output = {'probs': probs}
+        output = {"probs": probs}
         if label is not None:
             self.accuracy(logits, label)
             # Shape: (1,)
-            output['loss'] = torch.nn.functional.cross_entropy(logits, label)
+            output["loss"] = torch.nn.functional.cross_entropy(logits, label)
         return output
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:


### PR DESCRIPTION
the question is :[allennlp-guide/quick_start/predict.py need to update](https://github.com/allenai/allennlp-guide/issues/186)

so, i write a pr have 2 change :
1.the class `ClassificationTsvReader(DatasetReader):` need add a `def text_to_instance(self, text: str, label: str = None) -> Instance:` To accommodate predicter inputs;

2.the class `SimpleClassifier(Model):` need update `def forward(self, text: TextFieldTensors, label: torch.Tensor = None) -> Dict[str, torch.Tensor]:` To accommodate predicter inputs.
