### PR TITLE
Fix import path for gradient_descent_trainer

### DIFF
--- a/exercises/part1/training-and-prediction/training_setup.py
+++ b/exercises/part1/training-and-prediction/training_setup.py
@@ -20,7 +20,8 @@ from allennlp.modules.seq2vec_encoders import BagOfEmbeddingsEncoder
 from allennlp.modules.token_embedders import Embedding
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.nn import util
-from allennlp.training.trainer import GradientDescentTrainer, Trainer
+from allennlp.training.trainer import Trainer
+from allennlp.training.gradient_descent_trainer import GradientDescentTrainer
 from allennlp.training.optimizers import AdamOptimizer
 from allennlp.training.metrics import CategoricalAccuracy
 

--- a/quick_start/train.py
+++ b/quick_start/train.py
@@ -20,7 +20,8 @@ from allennlp.modules.seq2vec_encoders import BagOfEmbeddingsEncoder
 from allennlp.modules.token_embedders import Embedding
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.nn import util
-from allennlp.training.trainer import GradientDescentTrainer, Trainer
+from allennlp.training.trainer import Trainer
+from allennlp.training.gradient_descent_trainer import GradientDescentTrainer
 from allennlp.training.optimizers import AdamOptimizer
 from allennlp.training.metrics import CategoricalAccuracy
 


### PR DESCRIPTION
The current version has errors in Part1 and in the code for training in quick_start. https://github.com/allenai/allennlp-guide/issues/188#issue-973813793

GradientDescentTrainer is now imported from a different location.