### PR TITLE
Add text_to_instance method and optional label to prediction setup.

### DIFF
--- a/exercises/part1/training-and-prediction/prediction_setup.py
+++ b/exercises/part1/training-and-prediction/prediction_setup.py
@@ -41,16 +41,21 @@ class ClassificationTsvReader(DatasetReader):
         self.token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self.max_tokens = max_tokens
 
+    def text_to_instance(self, text: str, label: str = None) -> Instance:
+        tokens = self.tokenizer.tokenize(text)
+        if self.max_tokens:
+            tokens = tokens[: self.max_tokens]
+        text_field = TextField(tokens, self.token_indexers)
+        fields = {"text": text_field}
+        if label:
+            fields["label"] = LabelField(label)
+        return Instance(fields)
+
     def _read(self, file_path: str) -> Iterable[Instance]:
         with open(file_path, "r") as lines:
             for line in lines:
                 text, sentiment = line.strip().split("\t")
-                tokens = self.tokenizer.tokenize(text)
-                if self.max_tokens:
-                    tokens = tokens[: self.max_tokens]
-                text_field = TextField(tokens, self.token_indexers)
-                label_field = LabelField(sentiment)
-                yield Instance({"text": text_field, "label": label_field})
+                yield self.text_to_instance(text, sentiment)
 
 
 class SimpleClassifier(Model):
@@ -65,7 +70,7 @@ class SimpleClassifier(Model):
         self.accuracy = CategoricalAccuracy()
 
     def forward(
-        self, text: TextFieldTensors, label: torch.Tensor
+        self, text: TextFieldTensors, label: torch.Tensor = None
     ) -> Dict[str, torch.Tensor]:
         # Shape: (batch_size, num_tokens, embedding_dim)
         embedded_text = self.embedder(text)
@@ -77,10 +82,11 @@ class SimpleClassifier(Model):
         logits = self.classifier(encoded_text)
         # Shape: (batch_size, num_labels)
         probs = torch.nn.functional.softmax(logits)
-        # Shape: (1,)
-        loss = torch.nn.functional.cross_entropy(logits, label)
-        self.accuracy(logits, label)
-        output = {"loss": loss, "probs": probs}
+        output = {"probs": probs}
+        if label is not None:
+            self.accuracy(logits, label)
+            # Shape: (1,)
+            output["loss"] = torch.nn.functional.cross_entropy(logits, label)
         return output
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:


### PR DESCRIPTION
Add text_to_instance method and optional label to prediction setup to avoid runtime errors for this page of guide (https://guide.allennlp.org/training-and-prediction#4):
<img width="643" alt="Screenshot 2022-04-22 at 18 34 22" src="https://user-images.githubusercontent.com/50730282/164756844-57f3cfae-6d8a-405f-af63-47d7ce40128f.png">
.