### PR TITLE
Add incorrect predictions example for part1.

### DIFF
--- a/chapters/part1/training-and-prediction.md
+++ b/chapters/part1/training-and-prediction.md
@@ -477,6 +477,12 @@ When you run the code above, you should get results similar to:
 ```
 
 This means that at least for these instances your model is making correct predictions!
+However, your model can produce incorrect predictions like:
+```
+[('neg', 0.6124489307403564), ('pos', 0.38755106925964355)]
+[('neg', 0.7158600687980652), ('pos', 0.2841399013996124)]
+```
+It could be explained by different initialisation of weights of the neural model.
 
 ## From command line
 

--- a/chapters/part1/training-and-prediction.md
+++ b/chapters/part1/training-and-prediction.md
@@ -477,12 +477,7 @@ When you run the code above, you should get results similar to:
 ```
 
 This means that at least for these instances your model is making correct predictions!
-However, your model can produce incorrect predictions like:
-```
-[('neg', 0.6124489307403564), ('pos', 0.38755106925964355)]
-[('neg', 0.7158600687980652), ('pos', 0.2841399013996124)]
-```
-It could be explained by different initialisation of weights of the neural model.
+But don't be surprised if your model get those predictions wrong. That could happen because of random differences in your model's initialization and the training procedure.
 
 ## From command line
 


### PR DESCRIPTION
From run-to-run I was getting different classification results for these two specific examples (https://guide.allennlp.org/training-and-prediction#4).
<img width="542" alt="Screenshot 2022-04-22 at 18 43 09" src="https://user-images.githubusercontent.com/50730282/164758102-7a623cdc-18b7-45de-ad39-8a1eb261ee9b.png">
Possibly, we should add an explanation why it could happen to stop people thinking that they did something wrong.


