### PR TITLE
Fix typo in reading data page for Part 2

### DIFF
--- a/chapters/part2/reading-data.md
+++ b/chapters/part2/reading-data.md
@@ -227,7 +227,7 @@ In the simplest use case, you can just supply the `batch_size` parameter and it 
 
 <codeblock source="part2/reading-data/data_loader_basic" setup="part2/reading-data/data_loader_setup"></codeblock>
 
-You can easily customize how the `DataLoader` iterates over, samples, and/or batches the instances by specifying a [`BatchSampler`](http://docs.allennlp.org/main/api/data/samplers/batch_sampler/#batchsampler).
+You can easily customize how the `DataLoader` iterates over samples, and/or batches the instances by specifying a [`BatchSampler`](http://docs.allennlp.org/main/api/data/samplers/batch_sampler/#batchsampler).
 
 The [`BucketBatchSampler`](http://docs.allennlp.org/main/api/data/samplers/bucket_batch_sampler/#bucketbatchsampler) is the most important `BatchSampler` in practice and is a major feature of AllenNLP.
 It sorts the instances by the length of their longest `Field` (or by any sorting keys you specify)


### PR DESCRIPTION
Fixes extra comma from this page: https://guide.allennlp.org/reading-data#4

<img width="640" alt="Screenshot 2022-04-23 at 18 17 39" src="https://user-images.githubusercontent.com/50730282/164914405-cf3d6e91-200d-4d8e-9921-8ad57413668a.png">
